### PR TITLE
Update to latest versions of boto3 and awscli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 click==8.0.1
 Jinja2==3.0.1
 PyYAML==5.4.1
-awscli==1.20.48
+awscli==1.20.50
 requests==2.26.0
-boto3==1.18.36
+boto3==1.18.50
 docopt==0.6.2
 bcrypt==3.2.0
 yq==2.12.2


### PR DESCRIPTION
Dependabot can't handle this properly because both boto3 and awscli depend on botocore (see https://github.com/Crown-Commercial-Service/digitalmarketplace-aws/pull/1009). Update to the latest version of both, which both depend on the same version of botocore.