### PR TITLE
Remove Paula and Daniele

### DIFF
--- a/terraform/modules/iam-users/users/main.tf
+++ b/terraform/modules/iam-users/users/main.tf
@@ -1,13 +1,3 @@
-resource "aws_iam_user" "daniele_occhipinti" {
-  name          = "danieleocchipinti"
-  force_destroy = true
-}
-
-resource "aws_iam_user" "paula_valenca" {
-  name          = "paulavalenca"
-  force_destroy = true
-}
-
 resource "aws_iam_user" "benjamin_gill" {
   name          = "benjamingill"
   force_destroy = true


### PR DESCRIPTION
https://trello.com/c/LA87kjkQ/2359-remove-cdio-people-%F0%9F%91%8B

They're part of Cabinet Office CDIO. Since the end of the transition a couple of weeks ago, they are no longer involved with the DMP. So we should remove their access.

To be deployed alongside https://github.com/Crown-Commercial-Service/digitalmarketplace-credentials/pull/446 as part of https://crown-commercial-service.github.io/digitalmarketplace-manual/managing-people-and-secret-things/accounts.html#aws