### PR TITLE
Correct name of ACM validation DNS entry

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -31,7 +31,7 @@ module "preview_router" {
 
   cname_domain            = "d25mxit1hgdj3z.cloudfront.net"
   www_acm_value           = "_d3502b7f8e8375277e10b2a7a5c5184f.tfmgdnztqk.acm-validations.aws."
-  www_acm_name            = "_d3fce2c248a4041784f06c22a0090865.assets."
+  www_acm_name            = "_300d3b1b4424b600342366347505371a.www."
   api_acm_value           = "_bd3d82c6197b75e9ab21e7a60512f7ef.tfmgdnztqk.acm-validations.aws."
   api_acm_name            = "_588eb18af3dc5d8581c483bd3df00607.api."
   search_api_acm_value    = "_64f5fb82d733c1d2222e4aa64a03b037.tfmgdnztqk.acm-validations.aws."

--- a/terraform/modules/router/route53.tf
+++ b/terraform/modules/router/route53.tf
@@ -52,7 +52,7 @@ resource "aws_route53_record" "antivirus_api_acm_validation" {
 
 resource "aws_route53_record" "assets_acm_validation" {
   zone_id = aws_route53_zone.root.zone_id
-  name    = "${var.www_acm_name}${var.domain}"
+  name    = "${var.assets_acm_name}${var.domain}"
   type    = "CNAME"
   ttl     = "86400"
 


### PR DESCRIPTION
Previously, the ACM DNS entry for assets was using the same name as for www. I think this was a copy-paste error, because there exists an assets_acm_name variable that was defined but not used.

I think this should put a stop to the current dueling between assets and www, where terraform flips back and forth because they both have the same name.