### PR TITLE
Remove digitalmarketplace_prometheus service

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -15,7 +15,6 @@ api:
     - dm-api-{env}.cloudapps.digital/_metrics
   services:
     - digitalmarketplace_api_db
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
 
 search-api:
@@ -24,7 +23,6 @@ search-api:
     - dm-search-api-{env}.cloudapps.digital/_metrics
   services:
     - search_api_elasticsearch
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
 
 antivirus-api:
@@ -33,7 +31,6 @@ antivirus-api:
     - dm-antivirus-api-{env}.cloudapps.digital
     - dm-antivirus-api-{env}.cloudapps.digital/_metrics
   services:
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
 
 user-frontend:
@@ -41,7 +38,6 @@ user-frontend:
     - dm-{env}.cloudapps.digital/user
     - dm-{env}.cloudapps.digital/user/_metrics
   services:
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -50,7 +46,6 @@ admin-frontend:
     - dm-{env}.cloudapps.digital/admin
     - dm-{env}.cloudapps.digital/admin/_metrics
   services:
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -61,7 +56,6 @@ buyer-frontend:
     - dm-{env}.cloudapps.digital/_metrics
     - dm-{env}.cloudapps.digital/buyers/direct-award
   services:
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -71,7 +65,6 @@ supplier-frontend:
     - dm-{env}.cloudapps.digital/suppliers
     - dm-{env}.cloudapps.digital/suppliers/_metrics
   services:
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -80,7 +73,6 @@ briefs-frontend:
     - dm-{env}.cloudapps.digital/buyers
     - dm-{env}.cloudapps.digital/buyers/_metrics
   services:
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -89,7 +81,6 @@ brief-responses-frontend:
     - dm-{env}.cloudapps.digital/suppliers/opportunities
     - dm-{env}.cloudapps.digital/suppliers/opportunities/_metrics
   services:
-    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 


### PR DESCRIPTION
https://trello.com/c/CaH712GG/2443-update-paas-prometheus-exporter

We no longer have it hooked up to anything: it was GDS-specific, so we don't have access in CCS.